### PR TITLE
Feature/ong251-33 Validate role

### DIFF
--- a/src/main/java/com/alkemy/ong/config/security/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/alkemy/ong/config/security/auth/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.alkemy.ong.config.security.auth;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint{
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException authException) throws IOException, ServletException {
+		response.sendError(HttpServletResponse.SC_UNAUTHORIZED,authException.getMessage());
+	}
+}


### PR DESCRIPTION
Summary 

Protect endpoints that are only for the current user. It checks the ID parameter and compares it with the ID of the user sent in the JWT token, otherwise it returns a 403 error. However, if the user that is sent in the token is an administrator, it will allow him to continue.