### PR TITLE
ONG251-77 Add Endpoint Put comments by id

### DIFF
--- a/src/main/java/com/alkemy/ong/controllers/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controllers/CommentController.java
@@ -1,5 +1,8 @@
 package com.alkemy.ong.controllers;
 
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,8 +10,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,16 +31,24 @@ public class CommentController {
 
 	@Autowired
 	private ICommentService commentService;
-	
+
+	@PreAuthorize("hasRole('USER')")
 	@GetMapping()
-	ResponseEntity<Page<CommentListResponse>> getAllComents(@PageableDefault(size = 10) Pageable pageable){
+	ResponseEntity<Page<CommentListResponse>> getAllComents(@PageableDefault(size = 10) Pageable pageable) {
 		return ResponseEntity.ok(commentService.getAllComents(pageable));
 	}
-	
-	
+
+	@PreAuthorize("hasRole('USER')")
 	@PostMapping()
-	ResponseEntity<CommentResponse> create(@Valid @RequestBody CommentRequest commentRequest){
+	ResponseEntity<CommentResponse> create(@Valid @RequestBody CommentRequest commentRequest) {
 		return ResponseEntity.ok(commentService.save(commentRequest));
 	}
-	
+
+	@PreAuthorize("hasRole('USER')")
+	@PutMapping("/{id}")
+	@Transactional
+	public ResponseEntity<CommentResponse> update(@PathVariable UUID id,
+			@Valid @RequestBody CommentRequest commentRequest , HttpServletRequest httpServletRequest) {
+		return ResponseEntity.ok().body(commentService.update(id, commentRequest, httpServletRequest));
+	}
 }

--- a/src/main/java/com/alkemy/ong/exception/ForbiddenException.java
+++ b/src/main/java/com/alkemy/ong/exception/ForbiddenException.java
@@ -1,0 +1,11 @@
+package com.alkemy.ong.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public ForbiddenException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/com/alkemy/ong/exception/GlobalHandleException.java
+++ b/src/main/java/com/alkemy/ong/exception/GlobalHandleException.java
@@ -41,4 +41,11 @@ public class GlobalHandleException extends ResponseEntityExceptionHandler {
 				webRequest.getDescription(false));
 		return new ResponseEntity<>(ErrorDetails, HttpStatus.CONFLICT);
 	}
+	
+	@ExceptionHandler({ ForbiddenException.class })
+	public ResponseEntity<Object> handleOngRequestException(ForbiddenException exception, WebRequest webRequest) {
+		ErrorDetailsResponse ErrorDetails = new ErrorDetailsResponse(new Date(), exception.getMessage(),
+				webRequest.getDescription(false));
+		return new ResponseEntity<>(ErrorDetails, HttpStatus.FORBIDDEN);
+	}
 }

--- a/src/main/java/com/alkemy/ong/mappers/CommentMapper.java
+++ b/src/main/java/com/alkemy/ong/mappers/CommentMapper.java
@@ -50,6 +50,7 @@ public class CommentMapper {
 		comment.setUserId(userRepository.findById(commentRequest.getNewId()).get());
 		return comment;
 	}
+	
 
 
 }

--- a/src/main/java/com/alkemy/ong/repositories/CommentRepository.java
+++ b/src/main/java/com/alkemy/ong/repositories/CommentRepository.java
@@ -1,9 +1,11 @@
 package com.alkemy.ong.repositories;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.alkemy.ong.models.Comment;
@@ -12,5 +14,10 @@ import com.alkemy.ong.models.Comment;
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
 	List<Comment> findAllByOrderByTimestampsDesc();
+
+	 @Query(value = "select u.email " +
+	            "from comments c join users u on u.id = c.user_id " +
+	            "where c.comments_id = ?1", nativeQuery = true)
+	Optional<String> findOwnerEmail(UUID commentId);
 
 }

--- a/src/main/java/com/alkemy/ong/services/ICommentService.java
+++ b/src/main/java/com/alkemy/ong/services/ICommentService.java
@@ -1,5 +1,8 @@
 package com.alkemy.ong.services;
 
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import org.springframework.data.domain.Page;
@@ -15,5 +18,7 @@ public interface ICommentService {
 	Page<CommentListResponse> getAllComents(Pageable pageable);
 
 	CommentResponse save(@Valid CommentRequest commentRequest);
+
+	CommentResponse update(UUID id, @Valid CommentRequest updateCommentRequest, HttpServletRequest httpServletRequest);
 
 }

--- a/src/main/java/com/alkemy/ong/services/impl/CommentServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/services/impl/CommentServiceImpl.java
@@ -1,7 +1,10 @@
 package com.alkemy.ong.services.impl;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,9 +13,11 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import com.alkemy.ong.config.security.auth.JwtTokenProvider;
 import com.alkemy.ong.dto.request.comment.CommentRequest;
 import com.alkemy.ong.dto.response.comment.CommentListResponse;
 import com.alkemy.ong.dto.response.comment.CommentResponse;
+import com.alkemy.ong.exception.ForbiddenException;
 import com.alkemy.ong.exception.ResourceNotFoundException;
 import com.alkemy.ong.mappers.CommentMapper;
 import com.alkemy.ong.models.Comment;
@@ -32,6 +37,9 @@ public class CommentServiceImpl implements ICommentService {
 
 	@Autowired
 	private UserRepository userRepository;
+
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
 
 	@Autowired
 	private CommentMapper commentMapper;
@@ -64,5 +72,34 @@ public class CommentServiceImpl implements ICommentService {
 		return commentMapper.comments2CommentsResponse(
 				commentRepository.save(commentMapper.commentRequest2Comments(commentRequest)));
 
+	}
+
+	@Override
+	public CommentResponse update(UUID id, @Valid CommentRequest commentRequest,
+			HttpServletRequest httpServletRequest) {
+		String token = httpServletRequest.getHeader("Authorization").substring(7);
+		String email = jwtTokenProvider.GetUsernameJWT(token);
+		List<String> roles = jwtTokenProvider.extractRoles(token);
+
+		if (validUser(email, id) || isAdmin(roles)) {
+			Comment comment = commentMapper.commentRequest2Comments(commentRequest);
+			comment = commentRepository.findById(id)
+					.orElseThrow(() -> new ResourceNotFoundException("Comment", "id", id));
+			comment.setBody(comment.getBody());
+			commentRepository.save(comment);
+			return commentMapper.comments2CommentsResponse(comment);
+		}else {
+			throw new ForbiddenException("You do not have permission to modify this comment you need to be the owner or administrator");
+		}
+		
+	}
+
+	public Boolean validUser(String email, UUID commentId) {
+		Optional<String> owner = commentRepository.findOwnerEmail(commentId);
+		return owner.map(s -> s.equals(email)).orElse(false);
+	}
+
+	private boolean isAdmin(List<String> roles) {
+		return roles.contains("ADMIN");
 	}
 }


### PR DESCRIPTION

- PUT /comments/:id

- validate the existence of the comment based on its id. Only the user who made it or an administrator can edit a comment. I should return a 404 error code if the comment doesn't exist, or 403 if you don't have permission to modify it.